### PR TITLE
Add Endodontia to footer services list

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -138,6 +138,7 @@ export default function Footer() {
               <Typography variant="body2">Ortodontia</Typography>
               <Typography variant="body2">Clínica Geral</Typography>
               <Typography variant="body2">Odontopediatria</Typography>
+              <Typography variant="body2">Endodontia</Typography>
               <Typography variant="body2">Tratamentos Especializados</Typography>
             </Stack>
           </Grid>


### PR DESCRIPTION
## Summary
- include Endodontia in services column on the footer

## Testing
- `npm run format`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a921cee88328940a6804396b4d53