### PR TITLE
Remove 'Desde 2010' card from About section

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -86,26 +86,6 @@ export default function About() {
                     sx={{ height: { xs: 200, md: 300 } }}
                   />
                 </Card>
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    top: -10,
-                    left: -24,
-                    bgcolor: 'primary.main', // amarelo
-                    color: 'secondary.main',
-                    borderRadius: 2,
-                    px: 3,
-                    py: 1,
-                    boxShadow: 3,
-                    fontWeight: 500,
-                    fontSize: '1.1rem',
-                    zIndex: 2,
-                    minWidth: 120,
-                    textAlign: 'center',
-                  }}
-                >
-                  Desde 2010
-                </Box>
               </Box>
               <Typography
                 variant="h6"


### PR DESCRIPTION
## Summary
- remove overlay card with text "Desde 2010" in the About section

## Testing
- `npx --no-install prettier --write src/components/About.tsx`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865aafd6df083288bf47dccb18924ed