### PR TITLE
Fix service buttons to open WhatsApp

### DIFF
--- a/src/components/ClientServiceItem.tsx
+++ b/src/components/ClientServiceItem.tsx
@@ -73,8 +73,8 @@ export default function ClientServiceItem({ item, index }: ServiceItemProps) {
       default:
         return {
           text: item.btnName,
-          action: () => {},
-          ariaLabel: 'Saiba mais sobre este serviço',
+          action: () => window.open('https://wa.me/551633711212', '_blank'),
+          ariaLabel: 'Saiba mais sobre este serviço no WhatsApp',
         };
     }
   };


### PR DESCRIPTION
## Summary
- update default action in `ClientServiceItem` so generic service buttons open WhatsApp

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869283b99888328b0f5580f242a18dd