### PR TITLE
Atualizar Botão de Contato com Widget Estilizado

### DIFF
--- a/src/components/ChatBalloon.tsx
+++ b/src/components/ChatBalloon.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { Box, Paper, Typography, IconButton } from "@mui/material";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+
+interface ChatBalloonProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export default function ChatBalloon({ visible, onClose }: ChatBalloonProps) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          initial={{ y: 120, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 120, opacity: 0 }}
+          transition={{ type: "spring", stiffness: 400, damping: 32 }}
+          style={{
+            position: "fixed",
+            bottom: 110,
+            right: 24,
+            zIndex: 1300,
+            maxWidth: 420,
+          }}
+        >
+          <Paper
+            elevation={8}
+            sx={{
+              p: 1.5,
+              pr: 2,
+              background: (theme) => theme.palette.primary.main,
+              borderRadius: 3,
+              boxShadow: 6,
+              position: "relative",
+              display: "flex",
+              alignItems: "flex-start",
+              gap: 1.5,
+              maxHeight: 90,
+              '::after': {
+                content: '""',
+                position: 'absolute',
+                right: 19,
+                bottom: -16,
+                width: 0,
+                height: 0,
+                borderLeft: '12px solid transparent',
+                borderRight: '12px solid transparent',
+                borderTop: '16px solid',
+                borderTopColor: (theme) => theme.palette.primary.main,
+              },
+            }}
+          >
+            <IconButton
+              size="small"
+              onClick={onClose}
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                zIndex: 2,
+                color: '#d1b78f',
+              }}
+              aria-label="Fechar mensagem de contato"
+            >
+              <X size={18} />
+            </IconButton>
+            <Box>
+              <Typography variant="body1" sx={{ fontWeight: 500, mb: 0.5, color: '#d1b78f' }}>
+                Oi! Tudo bem? Me chamo Sofia, posso te ajudar com alguma dúvida?
+              </Typography>
+            </Box>
+          </Paper>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+} 

--- a/src/components/ChatWidgetGroup.tsx
+++ b/src/components/ChatWidgetGroup.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import ChatBalloon from "./ChatBalloon";
+import ImageWidget from "./ImageWidget";
+
+const APPEAR_DELAY = 10000; // 10 segundos
+const VISIBLE_TIME = 3 * 60 * 1000; // 3 minutos
+
+export default function ChatWidgetGroup() {
+  const [visible, setVisible] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const closeTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => {
+      setShouldRender(true);
+      setVisible(true);
+      closeTimerRef.current = setTimeout(() => {
+        setVisible(false);
+        setTimeout(() => setShouldRender(false), 500);
+      }, VISIBLE_TIME);
+    }, APPEAR_DELAY);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
+  const handleClose = () => {
+    setVisible(false);
+    setTimeout(() => setShouldRender(false), 500);
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+  };
+
+  if (!shouldRender) return null;
+
+  return (
+    <>
+      <ChatBalloon visible={visible} onClose={handleClose} />
+      {visible && (
+        <ImageWidget
+          imageSrc="/mayuri.jpeg"
+          alt="Logo Naturalize"
+          href="https://wa.me/551633711212"
+          backgroundColor="#1976d2"
+          hoverColor="#1565c0"
+          position={0}
+        />
+      )}
+    </>
+  );
+} 

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '@/theme';
 import dynamic from 'next/dynamic';
-import ImageWidget from './ImageWidget';
 import ChatWidgetGroup from './ChatWidgetGroup';
 
 const InstagramWidget = dynamic(() => import('./InstagramWidget'), { ssr: false });

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -4,6 +4,8 @@ import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import theme from '@/theme';
 import dynamic from 'next/dynamic';
+import ImageWidget from './ImageWidget';
+import ChatWidgetGroup from './ChatWidgetGroup';
 
 const InstagramWidget = dynamic(() => import('./InstagramWidget'), { ssr: false });
 
@@ -13,6 +15,7 @@ export default function ClientProviders({ children }: { children: React.ReactNod
       <CssBaseline />
       {children}
       {/* <StickyMobileCTA /> */}
+      <ChatWidgetGroup />
       <InstagramWidget />
     </ThemeProvider>
   );

--- a/src/components/ImageWidget.tsx
+++ b/src/components/ImageWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 import Image from "next/image";
 import { motion, AnimatePresence } from "framer-motion";
 

--- a/src/components/ImageWidget.tsx
+++ b/src/components/ImageWidget.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Box, IconButton } from "@mui/material";
+import Image from "next/image";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface ImageWidgetProps {
+  imageSrc: string;
+  alt?: string;
+  href: string;
+  backgroundColor?: string;
+  hoverColor?: string;
+  position?: number; // para empilhar widgets
+}
+
+export default function ImageWidget({
+  imageSrc,
+  alt = "Imagem do Widget",
+  href,
+  backgroundColor = "#1976d2",
+  hoverColor = "#1565c0",
+  position = 0,
+}: ImageWidgetProps) {
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ y: 120, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 120, opacity: 0 }}
+        transition={{ type: "spring", stiffness: 400, damping: 32 }}
+        style={{
+          position: "fixed",
+          bottom: 24 + position * 80,
+          right: 24,
+          zIndex: 1300,
+        }}
+      >
+        <IconButton
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          sx={{
+            width: 64,
+            height: 64,
+            background: backgroundColor,
+            borderRadius: "50%",
+            boxShadow: 6,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            overflow: "hidden",
+            position: "relative",
+            '&:hover': { background: hoverColor },
+          }}
+          aria-label={alt}
+        >
+          <Image src={imageSrc} alt={alt} fill style={{ objectFit: 'cover' }} />
+        </IconButton>
+      </motion.div>
+    </AnimatePresence>
+  );
+} 


### PR DESCRIPTION
Descrição:
- Avaliar a substituição do ícone do WhatsApp por um ícone do Chatwoot.
- O botão deve redirecionar para o canal de atendimento do Chatwoot.
- Adicionar um widget de mensagem automática após alguns segundos no site:
“Oi! Tudo bem? Me chamo Sofia, posso te ajudar com alguma dúvida?”
(Mensagem já definida — revisar texto final e tempo de exibição.)