### PR TITLE
feat: add Google Ads tag

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import { poppins, inter } from '@/theme';
 import './globals.css';
 import ClientProviders from '../components/ClientProviders';
@@ -20,6 +21,18 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt-BR" className={`${poppins.variable} ${inter.variable}`}>
+      <Script
+        src="https://www.googletagmanager.com/gtag/js?id=AW-16970300534"
+        strategy="afterInteractive"
+      />
+      <Script id="google-ads" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'AW-16970300534');
+        `}
+      </Script>
       <body>
         <ClientProviders>{children}</ClientProviders>
       </body>


### PR DESCRIPTION
## Summary
- add Google Ads gtag.js script in root layout using next/script

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896a7ed22548328864f2f67d00038b1